### PR TITLE
Fix motion-tracking crashes in `urcirobot.py`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -97,4 +97,4 @@ smpl_retarget/motion_data/
 smpl_retarget/retargeted_motion_data
 
 *.txt
-
+*~


### PR DESCRIPTION
- **Fix `dtype` bug** – cast `motion_ids` to long before indexing motion-lib
- **Avoid empty tensors** – sample two frames and add guards for batch size 0
- **Prevent size mismatch** – skip `my_quat_rotate` when no data
- **Reset clean-up** – reset `motion_time` and `ref_init_yaw` on `Reset()`
- **Update gitignore**: add `*~`.

