### PR TITLE
Fix motion load bug

### DIFF
--- a/humanoidverse/utils/motion_lib/torch_humanoid_batch.py
+++ b/humanoidverse/utils/motion_lib/torch_humanoid_batch.py
@@ -213,7 +213,9 @@ class Humanoid_Batch:
             return_dict.global_velocity = rigidbody_linear_velocity
             
             if len(self.cfg.extend_config) > 0:
-                return_dict.dof_pos = pose.sum(dim = -1)[..., 1:self.num_bodies] # you can sum it up since unitree's each joint has 1 dof. Last two are for hands. doesn't really matter. 
+                pos_clone = pose.clone()
+                pos_clone[0, :, 1:self.num_bodies] = pos_clone[0, :, 1:self.num_bodies] * self.dof_axis
+                return_dict.dof_pos = pos_clone.sum(dim=-1)[...,1:self.num_bodies]  # you can sum it up since unitree's each joint has 1 dof. Last two are for hands. doesn't really matter.
             else:
                 if not len(self.actuated_joints_idx) == len(self.body_names):
                     return_dict.dof_pos = pose.sum(dim = -1)[..., self.actuated_joints_idx]


### PR DESCRIPTION
In **fit_smpl_motion.py** _poss_new_aa_ has been multiplied by _dof_axis_, so when loading _dof_pos_ in isaac gym, it is necessary to remove the influence of _dof_axis_ on the positive and negative signs, otherwise the value of _dof_pos_ will be changed when the value of the axis exists -1.