### PR TITLE
Fix #68, matrix_from_quat with w_last=True

### DIFF
--- a/humanoidverse/deploy/urcirobot.py
+++ b/humanoidverse/deploy/urcirobot.py
@@ -431,7 +431,8 @@ class URCIRobot:
                 quat_inverse(root_quat, w_last=True),
                 robot_frame_anchor[1].squeeze(0),
                 w_last=True,
-            )
+            ),
+            w_last=True,
         )[..., :2].reshape(-1)
         # print("motion_res['root_rot']", motion_res['root_rot']);        breakpoint()
         return

--- a/humanoidverse/envs/motion_tracking/general_tracking.py
+++ b/humanoidverse/envs/motion_tracking/general_tracking.py
@@ -773,7 +773,8 @@ class LeggedRobotGeneralTracking(LeggedRobotBase):
                 quat_inverse(robot_anchor_quat_w_repeat, w_last=True),
                 self._rigid_body_rot_extend,
                 w_last=True,
-            )
+            ),
+            w_last=True,
         )[..., :2]
         self._obs_local_body_pos = quat_apply(
             quat_inverse(robot_anchor_quat_w_repeat, w_last=True),
@@ -785,7 +786,8 @@ class LeggedRobotGeneralTracking(LeggedRobotBase):
                 quat_inverse(self._rigid_body_rot_extend[:, self.anchor_index, :], w_last=True),
                 ref_body_rot_extend[:, self.anchor_index, :],
                 w_last=True,
-            )
+            ),
+            w_last=True,
         )[..., :2]
 
         self._obs_anchor_ref_pos = quat_apply(

--- a/humanoidverse/utils/torch_utils.py
+++ b/humanoidverse/utils/torch_utils.py
@@ -271,7 +271,7 @@ def yaw_quat(quat: torch.Tensor, w_last: bool = True) -> torch.Tensor:
 
 
 @torch.jit.script
-def matrix_from_quat(quaternions: torch.Tensor, w_last: bool = False) -> torch.Tensor:
+def matrix_from_quat(quaternions: torch.Tensor, w_last: bool = True) -> torch.Tensor:
     if w_last:
         i, j, k, r = torch.unbind(quaternions, -1)
     else:


### PR DESCRIPTION
This is a potential fix for #68.

Warning: this fix **breaks compatibility with previous code and trained checkpoints.**
Models trained before this change will not work with the updated logic.

Maybe further fixes, like version separation or a migration note, are needed.